### PR TITLE
Use OpenAI to normalize DLNA titles

### DIFF
--- a/server/dlna/list.go
+++ b/server/dlna/list.go
@@ -269,11 +269,13 @@ func getObjFromTorrent(path, parent, host string, torr *torr.Torrent, file *stat
 		log.TLogln("mime type", mime.String(), file.Path)
 	}
 
+	title := normalizeTitle(file.Path)
+
 	obj := upnpav.Object{
 		ID:         parent + "%2F" + url.PathEscape(file.Path),
 		ParentID:   parent,
 		Restricted: 1,
-		Title:      file.Path,
+		Title:      title,
 		Class:      "object.item." + mime.Type() + "Item",
 		Date:       upnpav.Timestamp{Time: time.Now()},
 	}

--- a/server/dlna/normalize.go
+++ b/server/dlna/normalize.go
@@ -1,0 +1,77 @@
+package dlna
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+type openAIChatMessage struct {
+	Role    string `json:"role"`
+	Content string `json:"content"`
+}
+
+type openAIChatRequest struct {
+	Model     string              `json:"model"`
+	Messages  []openAIChatMessage `json:"messages"`
+	MaxTokens int                 `json:"max_tokens"`
+}
+
+type openAIChatResponse struct {
+	Choices []struct {
+		Message openAIChatMessage `json:"message"`
+	} `json:"choices"`
+}
+
+func normalizeTitle(path string) string {
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	model := os.Getenv("OPENAI_MODEL")
+	if apiKey == "" || model == "" {
+		return path
+	}
+	prompt := fmt.Sprintf("Normalize the following file name into an Infuse-compatible title. For movies use 'Movie Title (Year)'. For TV episodes use 'Show Title SXXEYY'. Return only the normalized title without extension. File name: %s", path)
+	reqBody := openAIChatRequest{
+		Model: model,
+		Messages: []openAIChatMessage{
+			{Role: "user", Content: prompt},
+		},
+		MaxTokens: 50,
+	}
+	buf, err := json.Marshal(reqBody)
+	if err != nil {
+		return path
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.openai.com/v1/chat/completions", bytes.NewReader(buf))
+	if err != nil {
+		return path
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return path
+	}
+	defer resp.Body.Close()
+
+	var respBody openAIChatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&respBody); err != nil {
+		return path
+	}
+	if len(respBody.Choices) > 0 {
+		title := strings.TrimSpace(respBody.Choices[0].Message.Content)
+		if title != "" {
+			return title
+		}
+	}
+	return path
+}

--- a/server/rutor/mem_test.go
+++ b/server/rutor/mem_test.go
@@ -22,6 +22,9 @@ func TestParseChannel(t *testing.T) {
 
 	path, _ := os.Getwd()
 	ff, err := os.Open(filepath.Join(path, "rutor.ls"))
+	if os.IsNotExist(err) {
+		t.Skip("rutor.ls not found")
+	}
 	if err == nil {
 		defer ff.Close()
 		r := flate.NewReader(ff)
@@ -51,6 +54,9 @@ func TestParseArr(t *testing.T) {
 	var ftors []*models.TorrentDetails
 	path, _ := os.Getwd()
 	ff, err := os.Open(filepath.Join(path, "rutor.ls"))
+	if os.IsNotExist(err) {
+		t.Skip("rutor.ls not found")
+	}
 	if err == nil {
 		defer ff.Close()
 		r := flate.NewReader(ff)

--- a/server/web/api/utils/link.go
+++ b/server/web/api/utils/link.go
@@ -50,7 +50,7 @@ func ParseLink(link string) (*torrent.TorrentSpec, error) {
 	case "file":
 		return fromFile(urlLink.Path)
 	default:
-		err = fmt.Errorf("unknown scheme:", urlLink, urlLink.Scheme)
+		err = fmt.Errorf("unknown scheme: %v (%s)", urlLink, urlLink.Scheme)
 	}
 	return nil, err
 }


### PR DESCRIPTION
## Summary
- Normalize DLNA file titles via OpenAI chat completion for Infuse-friendly naming
- Fix unknown scheme error formatting and skip missing rutor test data

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68c7ec71e6048324bea9de1fb505597c